### PR TITLE
Migrated to .NET 6.0

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        dotnet: ["3.1.x", "5.0.x"]
+        dotnet: ["6.0.x"]
         os: [windows-latest, ubuntu-latest, macOS-latest]
 
     steps:

--- a/src/TOMAS.sln
+++ b/src/TOMAS.sln
@@ -3,9 +3,9 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.29709.97
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tomas.Kernel", "Tomas.Kernel\Tomas.Kernel.csproj", "{AF6338C3-342A-4A12-A25C-2D53C5568DA8}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tomas.Kernel", "Tomas.Kernel\Tomas.Kernel.csproj", "{AF6338C3-342A-4A12-A25C-2D53C5568DA8}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tomas.Common", "Tomas.Common\Tomas.Common.csproj", "{C50F3A6F-CFF4-4725-A1A5-21C5A2BC3321}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tomas.Common", "Tomas.Common\Tomas.Common.csproj", "{C50F3A6F-CFF4-4725-A1A5-21C5A2BC3321}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{59C9B3FC-B1EE-4C23-9BD9-D33074BF1334}"
 	ProjectSection(SolutionItems) = preProject

--- a/src/Tomas.Common/ComConsts.cs
+++ b/src/Tomas.Common/ComConsts.cs
@@ -1,15 +1,14 @@
 // I license this project under the GPL 3.0 license.
 // See the LICENSE file in the project root for more information.
-namespace Tomas.Common
-{
-    public struct ComConsts
-    {
-        /// <summary>
-        /// Name of the operating system
-        /// </summary>
-        public const string NAME = "TOMAS";
+namespace Tomas.Common;
 
-        public static string Version = $"{ThisAssembly.Git.SemVer.Major}.{ThisAssembly.Git.SemVer.Minor}.{ThisAssembly.Git.SemVer.Patch}";
-        public static string VersionGit = $"{Version}-{ThisAssembly.Git.Commit}";
-    }
+public struct ComConsts
+{
+    /// <summary>
+    /// Name of the operating system
+    /// </summary>
+    public const string NAME = "TOMAS";
+
+    public const string Version = $"{ThisAssembly.Git.SemVer.Major}.{ThisAssembly.Git.SemVer.Minor}.{ThisAssembly.Git.SemVer.Patch}";
+    public const string VersionGit = $"{Version}-{ThisAssembly.Git.Commit}";
 }

--- a/src/Tomas.Common/Programs/Clear.cs
+++ b/src/Tomas.Common/Programs/Clear.cs
@@ -1,14 +1,12 @@
-using System;
 using Tomas.Interface;
 
-namespace Tomas.Common.Programs
+namespace Tomas.Common.Programs;
+
+public class Clear : IProgram
 {
-    public class Clear : IProgram
+    public bool Run(IShell shell)
     {
-        public bool Run(IShell shell)
-        {
-            Console.Clear();
-            return true;
-        }
+        Console.Clear();
+        return true;
     }
 }

--- a/src/Tomas.Common/Programs/Commands.cs
+++ b/src/Tomas.Common/Programs/Commands.cs
@@ -1,17 +1,15 @@
-using System;
 using Tomas.Interface;
 
-namespace Tomas.Common.Programs
+namespace Tomas.Common.Programs;
+
+public class Commands : IProgram
 {
-    public class Commands : IProgram
+    public bool Run(IShell shell)
     {
-        public bool Run(IShell shell)
-        {
-            Console.WriteLine($"Commands:");
-            var progs = shell.Programs;
-            foreach (var commands in  progs.Keys)
-                Console.WriteLine(commands);
-            return true;
-        }
+        Console.WriteLine($"Commands:");
+        var progs = shell.Programs;
+        foreach (var commands in progs.Keys)
+            Console.WriteLine(commands);
+        return true;
     }
 }

--- a/src/Tomas.Common/Programs/FenSay.cs
+++ b/src/Tomas.Common/Programs/FenSay.cs
@@ -1,18 +1,17 @@
 // I license this project under the GPL 3.0 license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using Tomas.Interface;
 
-namespace Tomas.Common.Programs
-{
-    public class FenSay : IProgram
-    {
+namespace Tomas.Common.Programs;
 
-        /// <summary>
-        /// Fennec art by Todd Vargo
-        /// </summary>
-        const string _fennec = @"                \/
+public class FenSay : IProgram
+{
+
+    /// <summary>
+    /// Fennec art by Todd Vargo
+    /// </summary>
+    const string _fennec = @"                \/
    /\   /\
   //\\_//\\     ____
   \_     _/    /   /
@@ -23,20 +22,19 @@ namespace Tomas.Common.Programs
      [ [ /  \/ _/
     _[ [ \  /_/";
 
-         readonly string[] _phrases =
-         {
+    readonly string[] _phrases =
+    {
              "[SCREAMS IN FENNEC]",
              "Some people call me a coffee fox.",
              "Drink Soda. It makes you see faster.",
              "10/10, Wouldn't Recommend."
          };
 
-        public bool Run(IShell shell)
-        {
-            var rng = new Random();
-            var phrases = _phrases[rng.Next(_phrases.Length)];
-            Console.WriteLine($"{phrases}{Environment.NewLine}{_fennec}");
-            return true;
-        }
+    public bool Run(IShell shell)
+    {
+        var rng = new Random();
+        var phrases = _phrases[rng.Next(_phrases.Length)];
+        Console.WriteLine($"{phrases}{Environment.NewLine}{_fennec}");
+        return true;
     }
 }

--- a/src/Tomas.Common/Tomas.Common.csproj
+++ b/src/Tomas.Common/Tomas.Common.csproj
@@ -1,7 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
+        <Nullable>enable</Nullable>
+        <ImplicitUsings>enable</ImplicitUsings>
     </PropertyGroup>
 
     <ItemGroup>
@@ -9,7 +11,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="GitInfo" Version="2.1.2">
+      <PackageReference Include="GitInfo" Version="2.2.0">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>

--- a/src/Tomas.Interface/IProgram.cs
+++ b/src/Tomas.Interface/IProgram.cs
@@ -1,15 +1,14 @@
 // I license this project under the GPL 3.0 license.
 // See the LICENSE file in the project root for more information.
-namespace Tomas.Interface
+namespace Tomas.Interface;
+
+public interface IProgram
 {
-    public interface IProgram
-    {
-        /// <summary>
-        /// The program's main entry point. Boolean behaves as an exit point.
-        /// True and False are the equivalent to C's 0 and 1, i.e. "Success" and "Failure," respectfully.
-        /// </summary>
-        /// <param name="shell">Allows the program to interact with the shell.</param>
-        /// <returns>Exit back to shell.</returns>
-        bool Run(IShell shell);
-    }
+    /// <summary>
+    /// The program's main entry point. Boolean behaves as an exit point.
+    /// True and False are the equivalent to C's 0 and 1, i.e. "Success" and "Failure," respectfully.
+    /// </summary>
+    /// <param name="shell">Allows the program to interact with the shell.</param>
+    /// <returns>Exit back to shell.</returns>
+    bool Run(IShell shell);
 }

--- a/src/Tomas.Interface/IShell.cs
+++ b/src/Tomas.Interface/IShell.cs
@@ -1,14 +1,10 @@
 // I license this project under the GPL 3.0 license.
 // See the LICENSE file in the project root for more information.
+namespace Tomas.Interface;
 
-using System.Collections.Generic;
-
-namespace Tomas.Interface
+public interface IShell
 {
-    public interface IShell
-    {
-        string ReadLine { get; }
+    string ReadLine { get; }
 
-        Dictionary<string, IProgram> Programs { get; }
-    }
+    Dictionary<string, IProgram> Programs { get; }
 }

--- a/src/Tomas.Interface/Tomas.Interface.csproj
+++ b/src/Tomas.Interface/Tomas.Interface.csproj
@@ -1,7 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
+        <Nullable>enable</Nullable>
+        <ImplicitUsings>enable</ImplicitUsings>
     </PropertyGroup>
 
 </Project>

--- a/src/Tomas.Kernel/Kernel.cs
+++ b/src/Tomas.Kernel/Kernel.cs
@@ -1,66 +1,63 @@
 // I license this project under the GPL 3.0 license.
 // See the LICENSE file in the project root for more information.
-using System;
-using System.Collections.Generic;
 using Tomas.Common;
 using Sys = Cosmos.System;
 
-namespace Tomas.Kernel
+namespace Tomas.Kernel;
+
+public class Kernel : Sys.Kernel
 {
-    public class Kernel : Sys.Kernel
+    protected override void BeforeRun()
     {
-        protected override void BeforeRun()
+        try
         {
+            Sys.PCSpeaker.Beep();
+            TomFS.Initialize();
+        }
+        catch
+        {
+            Sys.PCSpeaker.Beep();
+            Console.WriteLine("File system failed to load! Not all functions will work.");
+        }
+
+
+        Console.WriteLine($"{ComConsts.NAME} v{ComConsts.VersionGit} Booted successfully.");
+    }
+
+    protected override void Run()
+    {
+        while (true)
+        {
+            var shell = new Shell();
+            var command = shell.ReadLine;
+
+            if (!OSConsts.Programs.TryGetValue(command, out var program))
+            {
+                Console.WriteLine("Command Unknown.");
+                continue;
+            }
+
             try
             {
-                Sys.PCSpeaker.Beep();
-                TomFS.Initialize();
+                var start = program.Run(shell);
+                switch (start)
+                {
+                    case true:
+                        continue;
+                    case false:
+                        Console.WriteLine("Program closed unexpectedly.");
+                        continue;
+                }
             }
-            catch
+            catch (Exception err)
             {
-                Sys.PCSpeaker.Beep();
-                Console.WriteLine("File system failed to load! Not all functions will work.");
-            }
-
-
-            Console.WriteLine($"{ComConsts.NAME} v{ComConsts.VersionGit} Booted successfully.");
-        }
-
-        protected override void Run()
-        {
-            while (true)
-            {
-                var shell = new Shell();
-                var command = shell.ReadLine;
-
-                if (!OSConsts.Programs.TryGetValue(command, out var program))
-                {
-                    Console.WriteLine("Command Unknown.");
-                    continue;
-                }
-
-                try
-                {
-                    var start = program.Run(shell);
-                    switch (start)
-                    {
-                        case true:
-                            continue;
-                        case false:
-                            Console.WriteLine("Program closed unexpectedly.");
-                            continue;
-                    }
-                }
-                catch (Exception err)
-                {
-                    Console.WriteLine(err.Message);
-                }
+                Console.WriteLine(err.Message);
             }
         }
+    }
 
-        protected override void AfterRun()
-        {
-            Console.WriteLine($"{ComConsts.NAME} is shutting down.");
-        }
+    protected override void AfterRun()
+    {
+        Console.WriteLine($"{ComConsts.NAME} is shutting down.");
     }
 }

--- a/src/Tomas.Kernel/Programs/About.cs
+++ b/src/Tomas.Kernel/Programs/About.cs
@@ -1,23 +1,20 @@
 // I license this project under the GPL 3.0 license.
 // See the LICENSE file in the project root for more information.
-
-using System;
 using Tomas.Common;
 using Tomas.Interface;
 
-namespace Tomas.Kernel.Programs
-{
-    public class About : IProgram
-    {
-        public bool Run(IShell shell)
-        {
-            Console.WriteLine($"{ComConsts.NAME} v{ComConsts.VersionGit}{Environment.NewLine}"
-                              + "TOMAS (Tony's Managed Operating System) is a operating system written in C# using the COSMOS framework.");
-            var progs = shell.Programs;
-            foreach (var commands in  progs.Keys)
-                Console.WriteLine(commands);
+namespace Tomas.Kernel.Programs;
 
-            return true;
-        }
+public class About : IProgram
+{
+    public bool Run(IShell shell)
+    {
+        Console.WriteLine($"{ComConsts.NAME} v{ComConsts.VersionGit}{Environment.NewLine}"
+                          + "TOMAS (Tony's Managed Operating System) is a operating system written in C# using the COSMOS framework.");
+        var progs = shell.Programs;
+        foreach (var commands in progs.Keys)
+            Console.WriteLine(commands);
+
+        return true;
     }
 }

--- a/src/Tomas.Kernel/Shell.cs
+++ b/src/Tomas.Kernel/Shell.cs
@@ -1,19 +1,17 @@
 // I license this project under the GPL 3.0 license.
 // See the LICENSE file in the project root for more information.
-using System;
-using System.Collections.Generic;
 using Tomas.Common.Programs;
 using Tomas.Interface;
 using Tomas.Kernel.Programs;
 using Sys = Cosmos.System;
 
-namespace Tomas.Kernel
-{
-    public class Shell : IShell
-    {
-        const char SYMBOL = '$';
+namespace Tomas.Kernel;
 
-        public Dictionary<string, IProgram> Programs => new Dictionary<string, IProgram>()
+public class Shell : IShell
+{
+    const char SYMBOL = '$';
+
+    public Dictionary<string, IProgram> Programs => new Dictionary<string, IProgram>()
         {
             {"about", new About()},
             {"fensay", new FenSay()},
@@ -21,14 +19,13 @@ namespace Tomas.Kernel
             {"commands", new Commands()}
         };
 
-        public string ReadLine
+    public string ReadLine
+    {
+        get
         {
-            get
-            {
-                Console.Write(SYMBOL);
-                var readl = Console.ReadLine();
-                return readl;
-            }
+            Console.Write(SYMBOL);
+            var readl = Console.ReadLine();
+            return readl;
         }
     }
 }

--- a/src/Tomas.Kernel/TomFS.cs
+++ b/src/Tomas.Kernel/TomFS.cs
@@ -1,51 +1,48 @@
 // I license this project under the GPL 3.0 license.
 // See the LICENSE file in the project root for more information.
-using System;
-using System.IO;
 using Cosmos.System.FileSystem;
 using Cosmos.System.FileSystem.VFS;
 
-namespace Tomas.Kernel
+namespace Tomas.Kernel;
+
+class TomFS
 {
-    class TomFS
+    public const string ROOT_DIR = "0:\\";
+    public static string SYSTEM_DIR = $"{ROOT_DIR}\\SYSTEM\\";
+
+    public static void Initialize()
     {
-        public const string ROOT_DIR = "0:\\";
-        public static string SYSTEM_DIR = $"{ROOT_DIR}\\SYSTEM\\";
-
-        public static void Initialize()
+        try
         {
-            try
-            {
-                var fs = new CosmosVFS();
-                VFSManager.RegisterVFS(fs);
-                fs.CreateDirectory(SYSTEM_DIR);
-                Console.WriteLine("Creating system files.");
-                fs.CreateFile($"{SYSTEM_DIR}sysinfo.txt");
-                Console.WriteLine("Setting system preferences.");
-                File.WriteAllText($"{SYSTEM_DIR}sysinfo.txt", $"{OSConsts.NAME}, {OSConsts.VersionGit}");
-                Console.WriteLine("File system loaded sucesfully.");
-                var intro = File.ReadAllText($"{SYSTEM_DIR}sysinfo.txt");
-                Console.WriteLine(intro);
+            var fs = new CosmosVFS();
+            VFSManager.RegisterVFS(fs);
+            fs.CreateDirectory(SYSTEM_DIR);
+            Console.WriteLine("Creating system files.");
+            fs.CreateFile($"{SYSTEM_DIR}sysinfo.txt");
+            Console.WriteLine("Setting system preferences.");
+            File.WriteAllText($"{SYSTEM_DIR}sysinfo.txt", $"{OSConsts.NAME}, {OSConsts.VersionGit}");
+            Console.WriteLine("File system loaded sucesfully.");
+            var intro = File.ReadAllText($"{SYSTEM_DIR}sysinfo.txt");
+            Console.WriteLine(intro);
 
-            }
-            catch
-            {
-                Console.WriteLine("File system failed to load! Not all functions will work.");
-            }
         }
-
-        public static string[] ListDirectories(string path)
+        catch
         {
-            try
-            {
-                var dirs = Directory.GetDirectories(path);
-                return dirs;
-            }
-            catch
-            {
-                Console.WriteLine("Failed to find any directories.");
-                throw;
-            }
+            Console.WriteLine("File system failed to load! Not all functions will work.");
+        }
+    }
+
+    public static string[] ListDirectories(string path)
+    {
+        try
+        {
+            var dirs = Directory.GetDirectories(path);
+            return dirs;
+        }
+        catch
+        {
+            Console.WriteLine("Failed to find any directories.");
+            throw;
         }
     }
 }

--- a/src/Tomas.Kernel/Tomas.Kernel.csproj
+++ b/src/Tomas.Kernel/Tomas.Kernel.csproj
@@ -1,7 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp2.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
+        <Nullable>enable</Nullable>
+        <ImplicitUsings>enable</ImplicitUsings>
         <RuntimeIdentifier>cosmos</RuntimeIdentifier>
         <SelfContained>True</SelfContained>
         <BinFormat>ELF</BinFormat>

--- a/src/Tomas.Terminal/Program.cs
+++ b/src/Tomas.Terminal/Program.cs
@@ -1,42 +1,34 @@
 ﻿// I license this project under the GPL 3.0 license.
 // See the LICENSE file in the project root for more information.
-using System;
+using Tomas.Terminal;
 
-namespace Tomas.Terminal
+while (true)
 {
-    class Program
+    var shell = new Shell();
+    var command = shell.ReadLine;
+    var programs = shell.Programs;
+
+    if (!programs.TryGetValue(command, out var program))
     {
-        static void Main()
+        Console.WriteLine("Command Not Found.");
+        continue;
+    }
+
+    try
+    {
+        var start = program.Run(shell);
+
+        switch (start)
         {
-            while (true)
-            {
-                var shell = new Shell();
-                var command = shell.ReadLine;
-                var programs = shell.Programs;
-
-                if (!programs.TryGetValue(command, out var program))
-                {
-                    Console.WriteLine("Command Not Found.");
-                    continue;
-                }
-
-                try
-                {
-                    var start = program.Run(shell);
-                    switch (start)
-                    {
-                        case true:
-                            continue;
-                        case false:
-                            Console.WriteLine("Program closed unexpectedly.");
-                            continue;
-                    }
-                }
-                catch (Exception err)
-                {
-                    Console.WriteLine(err.Message);
-                }
-            }
+            case true:
+                continue;
+            case false:
+                Console.WriteLine("Program closed unexpectedly.");
+                continue;
         }
+    }
+    catch (Exception err)
+    {
+        Console.WriteLine(err.Message);
     }
 }

--- a/src/Tomas.Terminal/Programs/About.cs
+++ b/src/Tomas.Terminal/Programs/About.cs
@@ -4,15 +4,13 @@ using System;
 using Tomas.Common;
 using Tomas.Interface;
 
-namespace Tomas.Terminal.Programs
+namespace Tomas.Terminal.Programs;
+
+public class About : IProgram
 {
-    public class About : IProgram
+    public bool Run(IShell shell)
     {
-        public bool Run(IShell shell)
-        {
-            Console.WriteLine($"{ComConsts.NAME} Terminal Emulator v{ComConsts.VersionGit}{Environment.NewLine}"
-                              + "TOMAS (Tony's Managed Operating System) is a operating system written in C# using the COSMOS framework.");
-            return true;
-        }
+        Console.WriteLine($"{ComConsts.NAME} (Tony's Managed Operating System) Terminal Emulator v{ComConsts.VersionGit}{Environment.NewLine}");
+        return true;
     }
 }

--- a/src/Tomas.Terminal/Shell.cs
+++ b/src/Tomas.Terminal/Shell.cs
@@ -1,33 +1,30 @@
 // I license this project under the GPL 3.0 license.
 // See the LICENSE file in the project root for more information.
-using System;
-using System.Collections.Generic;
 using Tomas.Common.Programs;
 using Tomas.Interface;
 using Tomas.Terminal.Programs;
 
-namespace Tomas.Terminal
+namespace Tomas.Terminal;
+
+public class Shell : IShell
 {
-    public class Shell : IShell
+    const char SYMBOL = '$';
+
+    public Dictionary<string, IProgram> Programs => new()
     {
-        const char SYMBOL = '$';
+        { "about", new About() },
+        { "fensay", new FenSay() },
+        { "clear", new Clear() },
+        { "commands", new Commands() }
+     };
 
-        public Dictionary<string, IProgram> Programs => new Dictionary<string, IProgram>()
+    public string ReadLine
+    {
+        get
         {
-            {"about", new About()},
-            {"fensay", new FenSay()},
-            {"clear", new Clear()},
-            {"commands", new Commands()}
-        };
-
-        public string ReadLine
-        {
-            get
-            {
-                Console.Write(SYMBOL);
-                var readl = Console.ReadLine();
-                return readl;
-            }
+            Console.Write(SYMBOL);
+            var readl = Console.ReadLine();
+            return readl!;
         }
     }
 }

--- a/src/Tomas.Terminal/Tomas.Terminal.csproj
+++ b/src/Tomas.Terminal/Tomas.Terminal.csproj
@@ -2,9 +2,9 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
-        <LangVersion>8</LangVersion>
-        <Nullable>warnings</Nullable>
+        <TargetFramework>net6.0</TargetFramework>
+        <Nullable>enable</Nullable>
+        <ImplicitUsings>enable</ImplicitUsings>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Kernal was migrated too but is unusable, at the moment. Stick with developing or testing from the terminal emulator.

## Project Changes

- Switched to file-scoped namespaces
- Enabled Implicit Usings and Nullable
- Code within terminal emulator's ``Program.cs`` is now top-level.